### PR TITLE
Add an internal only "compactMap" function for users still on swift 4.

### DIFF
--- a/RSParser.xcodeproj/project.pbxproj
+++ b/RSParser.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1ECE4B4F205FFE0F00DE952E /* Compatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ECE4B4E205FFE0F00DE952E /* Compatibility.swift */; };
 		6655164F2027549600E6ACB0 /* ParserData.h in Headers */ = {isa = PBXBuildFile; fileRef = 6655164C2027549600E6ACB0 /* ParserData.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		665516502027549600E6ACB0 /* RSParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 6655164D2027549600E6ACB0 /* RSParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		665516512027549600E6ACB0 /* ParserData.m in Sources */ = {isa = PBXBuildFile; fileRef = 6655164E2027549600E6ACB0 /* ParserData.m */; };
@@ -121,6 +122,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1ECE4B4E205FFE0F00DE952E /* Compatibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Compatibility.swift; path = Sources/Utilities/Compatibility.swift; sourceTree = "<group>"; };
 		6655164C2027549600E6ACB0 /* ParserData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ParserData.h; path = Sources/ParserData.h; sourceTree = "<group>"; };
 		6655164D2027549600E6ACB0 /* RSParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RSParser.h; path = Sources/RSParser.h; sourceTree = "<group>"; };
 		6655164E2027549600E6ACB0 /* ParserData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ParserData.m; path = Sources/ParserData.m; sourceTree = "<group>"; };
@@ -382,6 +384,7 @@
 				665516CA20287E8C00E6ACB0 /* RSDateParser.m */,
 				665516C420287E8C00E6ACB0 /* RSParserInternal.h */,
 				665516C920287E8C00E6ACB0 /* RSParserInternal.m */,
+				1ECE4B4E205FFE0F00DE952E /* Compatibility.swift */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";
@@ -648,6 +651,7 @@
 				6655165C202754B800E6ACB0 /* FeedParser.swift in Sources */,
 				6655167F202754EB00E6ACB0 /* RSRSSParser.m in Sources */,
 				665516A220287E3F00E6ACB0 /* JSONTypes.swift in Sources */,
+				1ECE4B4F205FFE0F00DE952E /* Compatibility.swift in Sources */,
 				665516D220287E8C00E6ACB0 /* RSDateParser.m in Sources */,
 				665516512027549600E6ACB0 /* ParserData.m in Sources */,
 				66551661202754B800E6ACB0 /* ParsedFeed.swift in Sources */,

--- a/Sources/Utilities/Compatibility.swift
+++ b/Sources/Utilities/Compatibility.swift
@@ -1,0 +1,19 @@
+//
+//  Compatibility.swift
+//  RSParser
+//
+//  Created by Cameron Pulsford on 3/19/18.
+//  Copyright © 2018 Ranchero Software, LLC. All rights reserved.
+//
+
+import Foundation
+
+internal extension Sequence {
+
+    #if swift(>=4.1)
+    #else
+    func compactMap<U>(_ transform: (Element) throws -> U?) rethrows -> [U] {
+        return try flatMap(transform)
+    }
+    #endif
+}


### PR DESCRIPTION
The [swift 4.1 only](https://github.com/apple/swift-evolution/blob/master/proposals/0187-introduce-filtermap.md) `compactMap` function is used a few times in this library. This PR adds a small shim layer so that the library officially supports back to swift 4 + Xcode 9.2 with the default toolchain.

I'm not sure what the intended swift target was here, so no hard feelings if you wanted to keep at 4.1 and higher!