### PR TITLE
Fix extra space in podspec

### DIFF
--- a/RSParser.podspec
+++ b/RSParser.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = "9.0"
   
   s.source       = { :git => "https://github.com/brentsimmons/RSParser.git", :tag => "#{s.version}" }
-  s.source_files  = "Sources", "Sources/**/*.{h,m, swift}"
+  s.source_files  = "Sources", "Sources/**/*.{h,m,swift}"
   s.library   = "xml2"
   s.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
 


### PR DESCRIPTION
Apparently an extra space was causing the swift files not to show up.