### PR TITLE
expose test results in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,4 +33,8 @@ jobs:
       # Build the app and run tests
       - run:
           name: build and test
-          command: xcodebuild -scheme RSParser test -showBuildTimingSummary
+          command: xcodebuild -scheme RSParser test -showBuildTimingSummary | xcpretty -r junit -o testout/unittests.xml
+      - store_test_results:
+          path: testout
+      - store_artifacts:
+          path: testout


### PR DESCRIPTION
Exposes the test results as an artifact through CircleCI

example build output: https://circleci.com/gh/heckj/RSParser/11

<img width="933" alt="Screen Shot 2019-06-13 at 4 56 54 PM" src="https://user-images.githubusercontent.com/43388/59474573-41febf80-8dfc-11e9-80a4-9b491f43f599.png">
