### PR TITLE
Use NSArray instead of NSSet for feed items

### DIFF
--- a/Sources/Feeds/JSON/JSONFeedParser.swift
+++ b/Sources/Feeds/JSON/JSONFeedParser.swift
@@ -114,11 +114,11 @@ private extension JSONFeedParser {
 		return hubs.isEmpty ? nil : Set(hubs)
 	}
 
-	static func parseItems(_ itemsArray: JSONArray, _ feedURL: String) -> Set<ParsedItem> {
+	static func parseItems(_ itemsArray: JSONArray, _ feedURL: String) -> [ParsedItem] {
 
-		return Set(itemsArray.compactMap { (oneItemDictionary) -> ParsedItem? in
+		return itemsArray.compactMap { (oneItemDictionary) -> ParsedItem? in
 			return parseItem(oneItemDictionary, feedURL)
-		})
+		}
 	}
 
 	static func parseItem(_ itemDictionary: JSONDictionary, _ feedURL: String) -> ParsedItem? {

--- a/Sources/Feeds/JSON/RSSInJSONParser.swift
+++ b/Sources/Feeds/JSON/RSSInJSONParser.swift
@@ -59,12 +59,12 @@ public struct RSSInJSONParser {
 
 private extension RSSInJSONParser {
 
-	static func parseItems(_ itemsObject: JSONArray, _ feedURL: String) -> Set<ParsedItem> {
+	static func parseItems(_ itemsObject: JSONArray, _ feedURL: String) -> [ParsedItem] {
 
-		return Set(itemsObject.compactMap{ (oneItemDictionary) -> ParsedItem? in
+		return itemsObject.compactMap{ (oneItemDictionary) -> ParsedItem? in
 
 			return parsedItemWithDictionary(oneItemDictionary, feedURL)
-		})
+		}
 	}
 
 	static func parsedItemWithDictionary(_ itemDictionary: JSONDictionary, _ feedURL: String) -> ParsedItem? {

--- a/Sources/Feeds/ParsedFeed.swift
+++ b/Sources/Feeds/ParsedFeed.swift
@@ -22,9 +22,9 @@ public struct ParsedFeed {
 	public let authors: Set<ParsedAuthor>?
 	public let expired: Bool
 	public let hubs: Set<ParsedHub>?
-	public let items: Set<ParsedItem>
+	public let items: [ParsedItem]
 
-	public init(type: FeedType, title: String?, homePageURL: String?, feedURL: String?, language: String?, feedDescription: String?, nextURL: String?, iconURL: String?, faviconURL: String?, authors: Set<ParsedAuthor>?, expired: Bool, hubs: Set<ParsedHub>?, items: Set<ParsedItem>) {
+	public init(type: FeedType, title: String?, homePageURL: String?, feedURL: String?, language: String?, feedDescription: String?, nextURL: String?, iconURL: String?, faviconURL: String?, authors: Set<ParsedAuthor>?, expired: Bool, hubs: Set<ParsedHub>?, items: [ParsedItem]) {
 		self.type = type
 		self.title = title
 		self.homePageURL = homePageURL?.nilIfEmptyOrWhitespace

--- a/Sources/Feeds/XML/RSParsedFeed.h
+++ b/Sources/Feeds/XML/RSParsedFeed.h
@@ -18,6 +18,6 @@
 @property (nonatomic, readonly, nullable) NSString *title;
 @property (nonatomic, readonly, nullable) NSString *link;
 @property (nonatomic, readonly, nullable) NSString *language;
-@property (nonatomic, readonly, nonnull) NSSet <RSParsedArticle *>*articles;
+@property (nonatomic, readonly, nonnull) NSArray <RSParsedArticle *>*articles;
 
 @end

--- a/Sources/Feeds/XML/RSParsedFeed.m
+++ b/Sources/Feeds/XML/RSParsedFeed.m
@@ -10,7 +10,7 @@
 
 @implementation RSParsedFeed
 
-- (instancetype)initWithURLString:(NSString *)urlString title:(NSString *)title link:(NSString *)link language:(NSString *)language articles:(NSSet *)articles {
+- (instancetype)initWithURLString:(NSString *)urlString title:(NSString *)title link:(NSString *)link language:(NSString *)language articles:(NSArray *)articles {
 	
 	self = [super init];
 	if (!self) {

--- a/Sources/Feeds/XML/RSParsedFeedTransformer.swift
+++ b/Sources/Feeds/XML/RSParsedFeedTransformer.swift
@@ -24,11 +24,9 @@ struct RSParsedFeedTransformer {
 
 private extension RSParsedFeedTransformer {
 
-	static func parsedItems(_ parsedArticles: Set<RSParsedArticle>) -> Set<ParsedItem> {
+	static func parsedItems(_ parsedArticles: [RSParsedArticle]) -> [ParsedItem] {
 
-		// Create Set<ParsedItem> from Set<RSParsedArticle>
-
-		return Set(parsedArticles.map(parsedItem))
+		return parsedArticles.map(parsedItem)
 	}
 
 	static func parsedItem(_ parsedArticle: RSParsedArticle) -> ParsedItem {


### PR DESCRIPTION
Using a NSSet loses the ordering given by the feed source.

I understand that this is a breaking API change and that you may not want to merge it but I’ll be using this branch for my project where I don’t want to re-order the feed items on the client.