### PR TITLE
Fix valid ".."s in URLs and don't return SVG favicon links

### DIFF
--- a/Sources/HTML/RSHTMLMetadata.m
+++ b/Sources/HTML/RSHTMLMetadata.m
@@ -199,7 +199,7 @@ static NSString *absoluteURLStringWithRelativeURLString(NSString *relativeURLStr
 	}
 
 	NSURL *absoluteURL = [NSURL URLWithString:relativeURLString relativeToURL:url];
-	return absoluteURL.standardizedURL.absoluteString;
+	return absoluteURL.absoluteURL.standardizedURL.absoluteString;
 }
 
 


### PR DESCRIPTION
The first part fixes an issue when trying to load a favicon like "../foo.ico" from a subdirectory (e.g., "https://example.com/bar/baz.html"); the second part fixes https://github.com/Ranchero-Software/NetNewsWire/issues/1753.