### PR TITLE
Fix tests

### DIFF
--- a/RSParserTests/HTMLLinkTests.swift
+++ b/RSParserTests/HTMLLinkTests.swift
@@ -23,7 +23,7 @@ class HTMLLinkTests: XCTestCase {
 	func testSixColorsLink() {
 
 		let d = parserData("sixcolors", "html", "http://sixcolors.com/")
-		let links = RSHTMLLinkParser.htmlLinks(with: d)!
+		let links = RSHTMLLinkParser.htmlLinks(with: d)
 
 		let linkToFind = "https://www.theincomparable.com/theincomparable/290/index.php"
 		let textToFind = "this week’s episode of The Incomparable"

--- a/RSParserTests/HTMLMetadataTests.swift
+++ b/RSParserTests/HTMLMetadataTests.swift
@@ -16,7 +16,7 @@ class HTMLMetadataTests: XCTestCase {
 		let d = parserData("DaringFireball", "html", "http://daringfireball.net/")
 		let metadata = RSHTMLMetadataParser.htmlMetadata(with: d)
 
-		XCTAssertEqual(metadata.faviconLinks.first, "http://daringfireball.net/graphics/favicon.ico?v=005")
+		XCTAssertEqual(metadata.favicons.first?.urlString, "http://daringfireball.net/graphics/favicon.ico?v=005")
 
 		XCTAssertEqual(metadata.feedLinks.count, 1)
 
@@ -40,7 +40,7 @@ class HTMLMetadataTests: XCTestCase {
 		let d = parserData("furbo", "html", "http://furbo.org/")
 		let metadata = RSHTMLMetadataParser.htmlMetadata(with: d)
 
-		XCTAssertEqual(metadata.faviconLinks.first, "http://furbo.org/favicon.ico")
+		XCTAssertEqual(metadata.favicons.first?.urlString, "http://furbo.org/favicon.ico")
 
 		XCTAssertEqual(metadata.feedLinks.count, 1)
 
@@ -63,7 +63,7 @@ class HTMLMetadataTests: XCTestCase {
 		let d = parserData("inessential", "html", "http://inessential.com/")
 		let metadata = RSHTMLMetadataParser.htmlMetadata(with: d)
 
-		XCTAssertNil(metadata.faviconLinks.first)
+		XCTAssertNil(metadata.favicons.first?.urlString)
 
 		XCTAssertEqual(metadata.feedLinks.count, 1)
 		let feedLink = metadata.feedLinks.first!
@@ -97,7 +97,7 @@ class HTMLMetadataTests: XCTestCase {
 		let d = parserData("sixcolors", "html", "http://sixcolors.com/")
 		let metadata = RSHTMLMetadataParser.htmlMetadata(with: d)
 
-		XCTAssertEqual(metadata.faviconLinks.first, "https://sixcolors.com/images/favicon.ico")
+		XCTAssertEqual(metadata.favicons.first?.urlString, "https://sixcolors.com/images/favicon.ico")
 
 		XCTAssertEqual(metadata.feedLinks.count, 1);
 		let feedLink = metadata.feedLinks.first!
@@ -125,7 +125,7 @@ class HTMLMetadataTests: XCTestCase {
 
 		let d = parserData("coco", "html", "https://www.theatlantic.com/entertainment/archive/2017/11/coco-is-among-pixars-best-movies-in-years/546695/")
 		let metadata = RSHTMLMetadataParser.htmlMetadata(with: d)
-		let openGraphData = metadata.openGraphProperties!
+		let openGraphData = metadata.openGraphProperties
 		let image = openGraphData.images.first!
 		XCTAssert(image.url == "https://cdn.theatlantic.com/assets/media/img/mt/2017/11/1033101_first_full_length_trailer_arrives_pixars_coco/facebook.jpg?1511382177")
 	}
@@ -134,7 +134,7 @@ class HTMLMetadataTests: XCTestCase {
 
 		let d = parserData("coco", "html", "https://www.theatlantic.com/entertainment/archive/2017/11/coco-is-among-pixars-best-movies-in-years/546695/")
 		let metadata = RSHTMLMetadataParser.htmlMetadata(with: d)
-		let twitterData = metadata.twitterProperties!
+		let twitterData = metadata.twitterProperties
 		let imageURL = twitterData.imageURL!
 		XCTAssert(imageURL == "https://cdn.theatlantic.com/assets/media/img/mt/2017/11/1033101_first_full_length_trailer_arrives_pixars_coco/facebook.jpg?1511382177")
 	}

--- a/Sources/HTML/RSHTMLLinkParser.h
+++ b/Sources/HTML/RSHTMLLinkParser.h
@@ -8,6 +8,8 @@
 
 @import Foundation;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*Returns all <a href="some_url">some_text</a> as RSHTMLLink object array.*/
 
 @class ParserData;
@@ -24,8 +26,10 @@
 
 // Any of these, even urlString, may be nil, because HTML can be bad.
 
-@property (nonatomic, readonly) NSString *urlString; //absolute
-@property (nonatomic, readonly) NSString *text;
-@property (nonatomic, readonly) NSString *title; //title attribute inside anchor tag
+@property (nonatomic, nullable, readonly) NSString *urlString; //absolute
+@property (nonatomic, nullable, readonly) NSString *text;
+@property (nonatomic, nullable, readonly) NSString *title; //title attribute inside anchor tag
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/HTML/RSHTMLMetadata.h
+++ b/Sources/HTML/RSHTMLMetadata.h
@@ -28,10 +28,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) NSArray <NSString *> *faviconLinks DEPRECATED_MSG_ATTRIBUTE("Use the favicons property instead.");
 @property (nonatomic, readonly) NSArray <RSHTMLMetadataFavicon *> *favicons;
-@property (nonatomic, nullable, readonly) NSArray <RSHTMLMetadataAppleTouchIcon *> *appleTouchIcons;
+@property (nonatomic, readonly) NSArray <RSHTMLMetadataAppleTouchIcon *> *appleTouchIcons;
 @property (nonatomic, readonly) NSArray <RSHTMLMetadataFeedLink *> *feedLinks;
 
-@property (nonatomic, nullable, readonly) RSHTMLOpenGraphProperties *openGraphProperties;
+@property (nonatomic, readonly) RSHTMLOpenGraphProperties *openGraphProperties;
 @property (nonatomic, readonly) RSHTMLTwitterProperties *twitterProperties;
 
 @end
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, nullable, readonly) NSString *title;
 @property (nonatomic, nullable, readonly) NSString *type;
-@property (nonatomic, nullable, readonly) NSString *urlString; // Absolute.
+@property (nonatomic, readonly) NSString *urlString; // Absolute.
 
 @end
 

--- a/Sources/HTML/RSHTMLMetadata.h
+++ b/Sources/HTML/RSHTMLMetadata.h
@@ -23,8 +23,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithURLString:(NSString *)urlString tags:(NSArray <RSHTMLTag *> *)tags;
 
-@property (nonatomic, readonly, nonnull) NSString *baseURLString;
-@property (nonatomic, readonly, nonnull) NSArray <RSHTMLTag *> *tags;
+@property (nonatomic, readonly) NSString *baseURLString;
+@property (nonatomic, readonly) NSArray <RSHTMLTag *> *tags;
 
 @property (nonatomic, readonly) NSArray <NSString *> *faviconLinks DEPRECATED_MSG_ATTRIBUTE("Use the favicons property instead.");
 @property (nonatomic, readonly) NSArray <RSHTMLMetadataFavicon *> *favicons;

--- a/Sources/HTML/RSHTMLMetadata.h
+++ b/Sources/HTML/RSHTMLMetadata.h
@@ -42,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) NSString *rel;
 @property (nonatomic, nullable, readonly) NSString *sizes;
 @property (nonatomic, readonly) CGSize size;
-@property (nonatomic, readonly) NSString *urlString; // Absolute.
+@property (nonatomic, nullable, readonly) NSString *urlString; // Absolute.
 
 @end
 
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, nullable, readonly) NSString *title;
 @property (nonatomic, nullable, readonly) NSString *type;
-@property (nonatomic, readonly) NSString *urlString; // Absolute.
+@property (nonatomic, nullable, readonly) NSString *urlString; // Absolute.
 
 @end
 

--- a/Sources/HTML/RSHTMLMetadata.m
+++ b/Sources/HTML/RSHTMLMetadata.m
@@ -88,7 +88,7 @@ static NSString *kTypeKey = @"type";
 
 	for (RSHTMLTag *tag in self.tags) {
 
-		if (tag.type != RSHTMLTagTypeLink || RSParserStringIsEmpty(tag.attributes[kHrefKey])) {
+		if (tag.type != RSHTMLTagTypeLink || RSParserStringIsEmpty(urlStringFromDictionary(tag.attributes))) {
 			continue;
 		}
 		NSString *oneRelValue = relValue(tag.attributes);

--- a/Sources/HTML/RSHTMLTag.h
+++ b/Sources/HTML/RSHTMLTag.h
@@ -8,6 +8,8 @@
 
 @import Foundation;
 
+NS_ASSUME_NONNULL_BEGIN
+
 extern NSString *RSHTMLTagNameLink; // @"link"
 extern NSString *RSHTMLTagNameMeta; // @"meta"
 
@@ -27,3 +29,5 @@ typedef NS_ENUM(NSInteger, RSHTMLTagType) {
 @property (nonatomic, readonly) NSDictionary *attributes;
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Contains a few other small changes:
- Fall back to the (technically-incorrect) `src` attribute for favicon `link` elements when there's no `href`.
- Change a few nullability annotations (because I forgot to switch branches and they're pretty minor) for things like `appleTouchIcons` that are initialized to empty arrays in their owner's `-init` and so can never be `nil` (barring some serious failure). One test also treated `appleTouchIcons` as `nonnull` already.
- Keep all `urlString` properties as `nullable` for now, until we can be certain that they'll never be `nil` under normal operation.