### PR TITLE
Use NSArray instead of NSSet for feed items

### DIFF
--- a/Sources/ObjC/RSParsedFeed.h
+++ b/Sources/ObjC/RSParsedFeed.h
@@ -18,6 +18,6 @@
 @property (nonatomic, readonly, nullable) NSString *title;
 @property (nonatomic, readonly, nullable) NSString *link;
 @property (nonatomic, readonly, nullable) NSString *language;
-@property (nonatomic, readonly, nonnull) NSSet <RSParsedArticle *>*articles;
+@property (nonatomic, readonly, nonnull) NSArray <RSParsedArticle *>*articles;
 
 @end

--- a/Sources/ObjC/RSParsedFeed.m
+++ b/Sources/ObjC/RSParsedFeed.m
@@ -12,7 +12,7 @@
 
 @implementation RSParsedFeed
 
-- (instancetype)initWithURLString:(NSString *)urlString title:(NSString *)title link:(NSString *)link language:(NSString *)language articles:(NSSet *)articles {
+- (instancetype)initWithURLString:(NSString *)urlString title:(NSString *)title link:(NSString *)link language:(NSString *)language articles:(NSArray *)articles {
 	
 	self = [super init];
 	if (!self) {

--- a/Sources/Swift/Feeds/JSON/JSONFeedParser.swift
+++ b/Sources/Swift/Feeds/JSON/JSONFeedParser.swift
@@ -117,11 +117,11 @@ private extension JSONFeedParser {
 		return hubs.isEmpty ? nil : Set(hubs)
 	}
 
-	static func parseItems(_ itemsArray: JSONArray, _ feedURL: String) -> Set<ParsedItem> {
+	static func parseItems(_ itemsArray: JSONArray, _ feedURL: String) -> [ParsedItem] {
 
-		return Set(itemsArray.compactMap { (oneItemDictionary) -> ParsedItem? in
+		return itemsArray.compactMap { (oneItemDictionary) -> ParsedItem? in
 			return parseItem(oneItemDictionary, feedURL)
-		})
+		}
 	}
 
 	static func parseItem(_ itemDictionary: JSONDictionary, _ feedURL: String) -> ParsedItem? {

--- a/Sources/Swift/Feeds/JSON/RSSInJSONParser.swift
+++ b/Sources/Swift/Feeds/JSON/RSSInJSONParser.swift
@@ -62,12 +62,12 @@ public struct RSSInJSONParser {
 
 private extension RSSInJSONParser {
 
-	static func parseItems(_ itemsObject: JSONArray, _ feedURL: String) -> Set<ParsedItem> {
+	static func parseItems(_ itemsObject: JSONArray, _ feedURL: String) -> [ParsedItem] {
 
-		return Set(itemsObject.compactMap{ (oneItemDictionary) -> ParsedItem? in
+		return itemsObject.compactMap{ (oneItemDictionary) -> ParsedItem? in
 
 			return parsedItemWithDictionary(oneItemDictionary, feedURL)
-		})
+		}
 	}
 
 	static func parsedItemWithDictionary(_ itemDictionary: JSONDictionary, _ feedURL: String) -> ParsedItem? {

--- a/Sources/Swift/Feeds/ParsedFeed.swift
+++ b/Sources/Swift/Feeds/ParsedFeed.swift
@@ -22,9 +22,9 @@ public struct ParsedFeed {
 	public let authors: Set<ParsedAuthor>?
 	public let expired: Bool
 	public let hubs: Set<ParsedHub>?
-	public let items: Set<ParsedItem>
+	public let items: [ParsedItem]
 
-	public init(type: FeedType, title: String?, homePageURL: String?, feedURL: String?, language: String?, feedDescription: String?, nextURL: String?, iconURL: String?, faviconURL: String?, authors: Set<ParsedAuthor>?, expired: Bool, hubs: Set<ParsedHub>?, items: Set<ParsedItem>) {
+	public init(type: FeedType, title: String?, homePageURL: String?, feedURL: String?, language: String?, feedDescription: String?, nextURL: String?, iconURL: String?, faviconURL: String?, authors: Set<ParsedAuthor>?, expired: Bool, hubs: Set<ParsedHub>?, items: [ParsedItem]) {
 		self.type = type
 		self.title = title
 		self.homePageURL = homePageURL?.nilIfEmptyOrWhitespace

--- a/Sources/Swift/Feeds/XML/RSParsedFeedTransformer.swift
+++ b/Sources/Swift/Feeds/XML/RSParsedFeedTransformer.swift
@@ -27,11 +27,9 @@ struct RSParsedFeedTransformer {
 
 private extension RSParsedFeedTransformer {
 
-	static func parsedItems(_ parsedArticles: Set<RSParsedArticle>) -> Set<ParsedItem> {
+	static func parsedItems(_ parsedArticles: [RSParsedArticle]) -> [ParsedItem] {
 
-		// Create Set<ParsedItem> from Set<RSParsedArticle>
-
-		return Set(parsedArticles.map(parsedItem))
+		return parsedArticles.map(parsedItem)
 	}
 
 	static func parsedItem(_ parsedArticle: RSParsedArticle) -> ParsedItem {


### PR DESCRIPTION
Using a NSSet loses the ordering given by the feed source.

I understand that this is a breaking API change and that you may not want to merge it but I’ll be using this branch for my project where I don’t want to re-order the feed items on the client.

(Same pull request as #46 but on the `main` branch.)