### PR TITLE
Adds RSS Item Categories as ParsedArticle Tags

### DIFF
--- a/Sources/ObjC/RSParsedArticle.h
+++ b/Sources/ObjC/RSParsedArticle.h
@@ -25,12 +25,14 @@
 @property (nonatomic, nullable) NSString *permalink;
 @property (nonatomic, nullable) NSSet<RSParsedAuthor *> *authors;
 @property (nonatomic, nullable) NSSet<RSParsedEnclosure *> *enclosures;
+@property (nonatomic, nullable) NSSet<NSString *> *categories;
 @property (nonatomic, nullable) NSDate *datePublished;
 @property (nonatomic, nullable) NSDate *dateModified;
 @property (nonatomic, nonnull) NSDate *dateParsed;
 @property (nonatomic, nullable)	NSString *language;
 
 - (void)addEnclosure:(RSParsedEnclosure *_Nonnull)enclosure;
+- (void)addCategory:(NSString *_Nonnull)category;
 - (void)addAuthor:(RSParsedAuthor *_Nonnull)author;
 
 @end

--- a/Sources/ObjC/RSParsedArticle.m
+++ b/Sources/ObjC/RSParsedArticle.m
@@ -60,6 +60,18 @@
 	}
 }
 
+#pragma mark - Categories
+
+- (void)addCategory:(NSString *)category {
+
+	if (self.categories) {
+		self.categories = [self.categories setByAddingObject:category];
+	}
+	else {
+		self.categories = [NSSet setWithObject:category];
+	}
+}
+
 #pragma mark - articleID
 
 - (NSString *)articleID {

--- a/Sources/ObjC/RSRSSParser.m
+++ b/Sources/ObjC/RSRSSParser.m
@@ -171,6 +171,9 @@ static const NSInteger kEnclosureLength = 10;
 static const char *kLanguage = "language";
 static const NSInteger kLanguageLength = 9;
 
+static const char *kCategory = "category";
+static const NSInteger kCategoryLength = 9;
+
 #pragma mark - Parsing
 
 - (void)parse {
@@ -240,6 +243,14 @@ static const NSInteger kLanguageLength = 9;
 	}
 }
 
+- (void)addCategoryWithString:(NSString *)categoryString {
+
+	if (RSParserStringIsEmpty(categoryString)) {
+		return;
+	}
+
+	[self.currentArticle addCategory:categoryString];
+}
 
 - (void)addGuid {
 
@@ -355,6 +366,9 @@ static const NSInteger kLanguageLength = 9;
 	}
 	else if (RSSAXEqualTags(localName, kLink, kLinkLength)) {
 		self.currentArticle.link = [self urlString:[self currentString]];
+	}
+	else if (RSSAXEqualTags(localName, kCategory, kCategoryLength)) {
+		[self addCategoryWithString:[self currentString]];
 	}
 	else if (RSSAXEqualTags(localName, kDescription, kDescriptionLength)) {
 

--- a/Sources/Swift/Feeds/XML/RSParsedFeedTransformer.swift
+++ b/Sources/Swift/Feeds/XML/RSParsedFeedTransformer.swift
@@ -46,8 +46,9 @@ private extension RSParsedFeedTransformer {
 		let dateModified = parsedArticle.dateModified
 		let authors = parsedAuthors(parsedArticle.authors)
 		let attachments = parsedAttachments(parsedArticle.enclosures)
+		let tags = parsedArticle.categories
 
-		return ParsedItem(syncServiceID: nil, uniqueID: uniqueID, feedURL: parsedArticle.feedURL, url: url, externalURL: externalURL, title: title, language: language, contentHTML: contentHTML, contentText: nil, summary: nil, imageURL: nil, bannerImageURL: nil, datePublished: datePublished, dateModified: dateModified, authors: authors, tags: nil, attachments: attachments)
+		return ParsedItem(syncServiceID: nil, uniqueID: uniqueID, feedURL: parsedArticle.feedURL, url: url, externalURL: externalURL, title: title, language: language, contentHTML: contentHTML, contentText: nil, summary: nil, imageURL: nil, bannerImageURL: nil, datePublished: datePublished, dateModified: dateModified, authors: authors, tags: tags, attachments: attachments)
 	}
 
 	static func parsedAuthors(_ authors: Set<RSParsedAuthor>?) -> Set<ParsedAuthor>? {

--- a/Tests/RSParserTests/RSSParserTests.swift
+++ b/Tests/RSParserTests/RSSParserTests.swift
@@ -175,6 +175,14 @@ class RSSParserTests: XCTestCase {
 		XCTAssertEqual(parsedFeed.language, "en-US")
 	}
 
+	func testFeedCategoriesAsTags() {
+		let d = parserData("dcrainmaker", "xml", "https://www.dcrainmaker.com/")
+		let parsedFeed = try! FeedParser.parse(d)!
+		for article in parsedFeed.items {
+			XCTAssertNotNil(article.tags)
+		}
+	}
+
 //	func testFeedWithGB2312Encoding() {
 //		// This feed has an encoding we don’t run into very often.
 //		// https://github.com/Ranchero-Software/NetNewsWire/issues/1477


### PR DESCRIPTION
I noticed that RSS Categories were not being parsed as tags. From my experience they are effectively interchangeable, so I included them as part of ParsedArticle.

I wasn't able to find an example Atom feed (either in the fixtures or cursorily browsing the web) so I didn't include parsing categories for Atom feeds in this change. It also seems like the Atom spec is a bit more involved -- categories in Atom aren't simple strings.

I've added a new test and it does pass. I apologize if my changes aren't paradigmatic; my Obj-C is *very* rusty.

---

btw, I'm using RSParser in a new app I'm developing and it's been a pleasure to use. Keep up the good work!