### PR TITLE
Add `rsparser_` prefix to NSData category methods.

### DIFF
--- a/Sources/ObjC/NSData+RSParser.h
+++ b/Sources/ObjC/NSData+RSParser.h
@@ -11,14 +11,14 @@
 
 @interface NSData (RSParser)
 
-- (BOOL)isProbablyHTML;
-- (BOOL)isProbablyXML;
-- (BOOL)isProbablyJSON;
+- (BOOL)rsparser_isProbablyHTML;
+- (BOOL)rsparser_isProbablyXML;
+- (BOOL)rsparser_isProbablyJSON;
 
-- (BOOL)isProbablyJSONFeed;
-- (BOOL)isProbablyRSSInJSON;
-- (BOOL)isProbablyRSS;
-- (BOOL)isProbablyAtom;
+- (BOOL)rsparser_isProbablyJSONFeed;
+- (BOOL)rsparser_isProbablyRSSInJSON;
+- (BOOL)rsparser_isProbablyRSS;
+- (BOOL)rsparser_isProbablyAtom;
 
 @end
 

--- a/Sources/ObjC/NSData+RSParser.m
+++ b/Sources/ObjC/NSData+RSParser.m
@@ -23,32 +23,32 @@ static BOOL bytesStartWithAtom(const char *bytes, NSUInteger numberOfBytes);
 
 @implementation NSData (RSParser)
 
-- (BOOL)isProbablyHTML {
+- (BOOL)rsparser_isProbablyHTML {
 
 	return bytesAreProbablyHTML(self.bytes, self.length);
 }
 
-- (BOOL)isProbablyXML {
+- (BOOL)rsparser_isProbablyXML {
 
 	return bytesAreProbablyXML(self.bytes, self.length);
 }
 
-- (BOOL)isProbablyJSON {
+- (BOOL)rsparser_isProbablyJSON {
 
 	return bytesStartWithStringIgnoringWhitespace("{", self.bytes, self.length);
 }
 
-- (BOOL)isProbablyJSONFeed {
+- (BOOL)rsparser_isProbablyJSONFeed {
 
-	if (![self isProbablyJSON]) {
+	if (![self rsparser_isProbablyJSON]) {
 		return NO;
 	}
 	return didFindString("://jsonfeed.org/version/", self.bytes, self.length) || didFindString(":\\/\\/jsonfeed.org\\/version\\/", self.bytes, self.length);
 }
 
-- (BOOL)isProbablyRSSInJSON {
+- (BOOL)rsparser_isProbablyRSSInJSON {
 
-	if (![self isProbablyJSON]) {
+	if (![self rsparser_isProbablyJSON]) {
 		return NO;
 	}
 	const char *bytes = self.bytes;
@@ -56,7 +56,7 @@ static BOOL bytesStartWithAtom(const char *bytes, NSUInteger numberOfBytes);
 	return didFindString("rss", bytes, length) && didFindString("channel", bytes, length) && didFindString("item", bytes, length);
 }
 
-- (BOOL)isProbablyRSS {
+- (BOOL)rsparser_isProbablyRSS {
 
 	if (didFindString("<rss", self.bytes, self.length) || didFindString("<rdf:RDF", self.bytes, self.length)) {
 		return YES;
@@ -66,7 +66,7 @@ static BOOL bytesStartWithAtom(const char *bytes, NSUInteger numberOfBytes);
 	return (didFindString("<channel>", self.bytes, self.length) && didFindString("<pubDate>", self.bytes, self.length));
 }
 
-- (BOOL)isProbablyAtom {
+- (BOOL)rsparser_isProbablyAtom {
 
 	return didFindString("<feed", self.bytes, self.length);
 }

--- a/Sources/Swift/Feeds/FeedType.swift
+++ b/Sources/Swift/Feeds/FeedType.swift
@@ -37,20 +37,20 @@ public func feedType(_ parserData: ParserData, isPartialData: Bool = false) -> F
 
 	let nsdata = parserData.data as NSData
 
-	if nsdata.isProbablyJSONFeed() {
+	if nsdata.rsparser_isProbablyJSONFeed() {
 		return .jsonFeed
 	}
-	if nsdata.isProbablyRSSInJSON() {
+	if nsdata.rsparser_isProbablyRSSInJSON() {
 		return .rssInJSON
 	}
-	if nsdata.isProbablyRSS() {
+	if nsdata.rsparser_isProbablyRSS() {
 		return .rss
 	}
-	if nsdata.isProbablyAtom() {
+	if nsdata.rsparser_isProbablyAtom() {
 		return .atom
 	}
 
-	if isPartialData && nsdata.isProbablyJSON() {
+	if isPartialData && nsdata.rsparser_isProbablyJSON() {
 		// Might not be able to detect a JSON Feed without all data.
 		// Dr. Drang’s JSON Feed (see althis.json and allthis-partial.json in tests)
 		// has, at this writing, the JSON version element at the end of the feed,


### PR DESCRIPTION
This PR adds `rsparser_` prefix to NSData category methods, same as NSString+RSParser. This helps preventing name collisions.