### PR TITLE
Add proper nullability specifiers for all public ObjC headers.

### DIFF
--- a/Sources/ObjC/FeedParser.h
+++ b/Sources/ObjC/FeedParser.h
@@ -8,17 +8,21 @@
 
 @import Foundation;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class RSParsedFeed;
 @class RSXMLData;
 
 
 @protocol FeedParser <NSObject>
 
-+ (BOOL)canParseFeed:(RSXMLData * _Nonnull)xmlData;
++ (BOOL)canParseFeed:(RSXMLData *)xmlData;
 
-- (nonnull instancetype)initWithXMLData:(RSXMLData * _Nonnull)xmlData;
+- (instancetype)initWithXMLData:(RSXMLData *)xmlData;
 
-- (nullable RSParsedFeed *)parseFeed:(NSError * _Nullable * _Nullable)error;
+- (nullable RSParsedFeed *)parseFeed:(NSError **)error;
 
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/ObjC/NSData+RSParser.h
+++ b/Sources/ObjC/NSData+RSParser.h
@@ -8,6 +8,7 @@
 
 @import Foundation;
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface NSData (RSParser)
 
@@ -22,5 +23,6 @@
 
 @end
 
+NS_ASSUME_NONNULL_END
 
 

--- a/Sources/ObjC/ParserData.h
+++ b/Sources/ObjC/ParserData.h
@@ -15,7 +15,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) NSString *url;
 @property (nonatomic, readonly) NSData *data;
 
-- (instancetype)initWithURL:(NSString *)url data:(NSData *)data;
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithURL:(NSString *)url data:(NSData *)data NS_DESIGNATED_INITIALIZER;
 
 @end
 

--- a/Sources/ObjC/RSAtomParser.h
+++ b/Sources/ObjC/RSAtomParser.h
@@ -11,8 +11,12 @@
 @class ParserData;
 @class RSParsedFeed;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface RSAtomParser : NSObject
 
 + (RSParsedFeed *)parseFeedWithData:(ParserData *)parserData;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/ObjC/RSAtomParser.m
+++ b/Sources/ObjC/RSAtomParser.m
@@ -307,8 +307,7 @@ static const NSInteger kLengthLength = 7;
 
 - (RSParsedEnclosure *)enclosureWithURLString:(NSString *)urlString attributes:(NSDictionary *)attributes {
 
-	RSParsedEnclosure *enclosure = [[RSParsedEnclosure alloc] init];
-	enclosure.url = urlString;
+	RSParsedEnclosure *enclosure = [[RSParsedEnclosure alloc] initWithURLString:urlString];
 	enclosure.title = attributes[kTitleKey];
 	enclosure.mimeType = attributes[kTypeKey];
 	enclosure.length = [attributes[kLengthKey] integerValue];

--- a/Sources/ObjC/RSDateParser.h
+++ b/Sources/ObjC/RSDateParser.h
@@ -8,15 +8,17 @@
 
 @import Foundation;
 
+NS_ASSUME_NONNULL_BEGIN
 
 // Common web dates -- RFC 822 and 8601 -- are handled here: the formats you find in JSON and XML feeds.
 // These may return nil. They may also return garbage, given bad input.
 
-NSDate *RSDateWithString(NSString *dateString);
+NSDate * _Nullable RSDateWithString(NSString *dateString);
 
 // If you're using a SAX parser, you have the bytes and don't need to convert to a string first.
 // It's faster and uses less memory.
 // (Assumes bytes are UTF-8 or ASCII. If you're using the libxml SAX parser, this will work.)
 
-NSDate *RSDateWithBytes(const char *bytes, NSUInteger numberOfBytes);
+NSDate * _Nullable RSDateWithBytes(const char *bytes, NSUInteger numberOfBytes);
 
+NS_ASSUME_NONNULL_END

--- a/Sources/ObjC/RSHTMLMetadata.h
+++ b/Sources/ObjC/RSHTMLMetadata.h
@@ -21,7 +21,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RSHTMLMetadata : NSObject
 
-- (instancetype)initWithURLString:(NSString *)urlString tags:(NSArray <RSHTMLTag *> *)tags;
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithURLString:(NSString *)urlString tags:(NSArray <RSHTMLTag *> *)tags NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, readonly) NSString *baseURLString;
 @property (nonatomic, readonly) NSArray <RSHTMLTag *> *tags;
@@ -67,7 +68,8 @@ NS_ASSUME_NONNULL_BEGIN
 // TODO: the rest. At this writing (Nov. 26, 2017) I just care about og:image.
 // See http://ogp.me/
 
-- (instancetype)initWithURLString:(NSString *)urlString tags:(NSArray <RSHTMLTag *> *)tags;
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithURLString:(NSString *)urlString tags:(NSArray <RSHTMLTag *> *)tags NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, readonly) NSArray <RSHTMLOpenGraphImage *> *images;
 

--- a/Sources/ObjC/RSHTMLMetadata.h
+++ b/Sources/ObjC/RSHTMLMetadata.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RSHTMLMetadataAppleTouchIcon : NSObject
 
-@property (nonatomic, readonly) NSString *rel;
+@property (nonatomic, nullable, readonly) NSString *rel;
 @property (nonatomic, nullable, readonly) NSString *sizes;
 @property (nonatomic, readonly) CGSize size;
 @property (nonatomic, nullable, readonly) NSString *urlString; // Absolute.

--- a/Sources/ObjC/RSHTMLTag.h
+++ b/Sources/ObjC/RSHTMLTag.h
@@ -20,7 +20,8 @@ typedef NS_ENUM(NSInteger, RSHTMLTagType) {
 
 @interface RSHTMLTag : NSObject
 
-- (instancetype)initWithType:(RSHTMLTagType)type attributes:(NSDictionary *)attributes;
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithType:(RSHTMLTagType)type attributes:(NSDictionary *)attributes NS_DESIGNATED_INITIALIZER;
 
 + (RSHTMLTag *)linkTagWithAttributes:(NSDictionary *)attributes;
 + (RSHTMLTag *)metaTagWithAttributes:(NSDictionary *)attributes;

--- a/Sources/ObjC/RSOPMLAttributes.h
+++ b/Sources/ObjC/RSOPMLAttributes.h
@@ -8,6 +8,8 @@
 
 @import Foundation;
 
+NS_ASSUME_NONNULL_BEGIN
+
 // OPML allows for arbitrary attributes.
 // These are the common attributes in OPML files used as RSS subscription lists.
 
@@ -25,12 +27,14 @@ extern NSString *OPMLXMLURLKey; //xmlUrl
 // A frequent error in OPML files is to mess up the capitalization,
 // so these do a case-insensitive lookup.
 
-@property (nonatomic, readonly) NSString *opml_text;
-@property (nonatomic, readonly) NSString *opml_title;
-@property (nonatomic, readonly) NSString *opml_description;
-@property (nonatomic, readonly) NSString *opml_type;
-@property (nonatomic, readonly) NSString *opml_version;
-@property (nonatomic, readonly) NSString *opml_htmlUrl;
-@property (nonatomic, readonly) NSString *opml_xmlUrl;
+@property (nonatomic, nullable, readonly) NSString *opml_text;
+@property (nonatomic, nullable, readonly) NSString *opml_title;
+@property (nonatomic, nullable, readonly) NSString *opml_description;
+@property (nonatomic, nullable, readonly) NSString *opml_type;
+@property (nonatomic, nullable, readonly) NSString *opml_version;
+@property (nonatomic, nullable, readonly) NSString *opml_htmlUrl;
+@property (nonatomic, nullable, readonly) NSString *opml_xmlUrl;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/ObjC/RSOPMLDocument.h
+++ b/Sources/ObjC/RSOPMLDocument.h
@@ -12,10 +12,13 @@
 
 
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface RSOPMLDocument : RSOPMLItem
 
-@property (nonatomic) NSString *title;
-@property (nonatomic) NSString *url;
+@property (nonatomic, nullable) NSString *title;
+@property (nonatomic, nullable) NSString *url;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/ObjC/RSOPMLError.h
+++ b/Sources/ObjC/RSOPMLError.h
@@ -8,6 +8,8 @@
 
 @import Foundation;
 
+NS_ASSUME_NONNULL_BEGIN
+
 extern NSString *RSOPMLErrorDomain;
 
 
@@ -17,3 +19,5 @@ typedef NS_ENUM(NSInteger, RSOPMLErrorCode) {
 
 
 NSError *RSOPMLWrongFormatError(NSString *fileName);
+
+NS_ASSUME_NONNULL_END

--- a/Sources/ObjC/RSOPMLFeedSpecifier.h
+++ b/Sources/ObjC/RSOPMLFeedSpecifier.h
@@ -12,7 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RSOPMLFeedSpecifier : NSObject
 
-- (instancetype)initWithTitle:(NSString * _Nullable)title feedDescription:(NSString * _Nullable)feedDescription homePageURL:(NSString * _Nullable)homePageURL feedURL:(NSString *)feedURL;
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithTitle:(NSString * _Nullable)title feedDescription:(NSString * _Nullable)feedDescription homePageURL:(NSString * _Nullable)homePageURL feedURL:(NSString *)feedURL NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, nullable, readonly) NSString *title;
 @property (nonatomic, nullable, readonly) NSString *feedDescription;

--- a/Sources/ObjC/RSOPMLParser.h
+++ b/Sources/ObjC/RSOPMLParser.h
@@ -12,7 +12,9 @@
 @class ParserData;
 @class RSOPMLDocument;
 
-typedef void (^OPMLParserCallback)(RSOPMLDocument *opmlDocument, NSError *error);
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^OPMLParserCallback)(RSOPMLDocument * _Nullable opmlDocument, NSError * _Nullable error);
 
 // Parses on background thread; calls back on main thread.
 void RSParseOPML(ParserData *parserData, OPMLParserCallback callback);
@@ -20,7 +22,8 @@ void RSParseOPML(ParserData *parserData, OPMLParserCallback callback);
 
 @interface RSOPMLParser: NSObject
 
-+ (RSOPMLDocument *)parseOPMLWithParserData:(ParserData *)parserData error:(NSError **)error;
++ (nullable RSOPMLDocument *)parseOPMLWithParserData:(ParserData *)parserData error:(NSError **)error;
 
 @end
 
+NS_ASSUME_NONNULL_END

--- a/Sources/ObjC/RSParsedArticle.h
+++ b/Sources/ObjC/RSParsedArticle.h
@@ -15,7 +15,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RSParsedArticle : NSObject
 
-- (instancetype)initWithFeedURL:(NSString *)feedURL;
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithFeedURL:(NSString *)feedURL NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, readonly) NSString *feedURL;
 @property (nonatomic) NSString *articleID; //guid, if present, or calculated from other attributes. Should be unique to the feed, but not necessarily unique across different feeds. (Not suitable for a database ID.)

--- a/Sources/ObjC/RSParsedArticle.h
+++ b/Sources/ObjC/RSParsedArticle.h
@@ -11,12 +11,14 @@
 @class RSParsedEnclosure;
 @class RSParsedAuthor;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface RSParsedArticle : NSObject
 
-- (nonnull instancetype)initWithFeedURL:(NSString * _Nonnull)feedURL;
+- (instancetype)initWithFeedURL:(NSString *)feedURL;
 
-@property (nonatomic, readonly, nonnull) NSString *feedURL;
-@property (nonatomic, nonnull) NSString *articleID; //guid, if present, or calculated from other attributes. Should be unique to the feed, but not necessarily unique across different feeds. (Not suitable for a database ID.)
+@property (nonatomic, readonly) NSString *feedURL;
+@property (nonatomic) NSString *articleID; //guid, if present, or calculated from other attributes. Should be unique to the feed, but not necessarily unique across different feeds. (Not suitable for a database ID.)
 
 @property (nonatomic, nullable) NSString *guid;
 @property (nonatomic, nullable) NSString *title;
@@ -27,11 +29,12 @@
 @property (nonatomic, nullable) NSSet<RSParsedEnclosure *> *enclosures;
 @property (nonatomic, nullable) NSDate *datePublished;
 @property (nonatomic, nullable) NSDate *dateModified;
-@property (nonatomic, nonnull) NSDate *dateParsed;
+@property (nonatomic) NSDate *dateParsed;
 @property (nonatomic, nullable)	NSString *language;
 
-- (void)addEnclosure:(RSParsedEnclosure *_Nonnull)enclosure;
-- (void)addAuthor:(RSParsedAuthor *_Nonnull)author;
+- (void)addEnclosure:(RSParsedEnclosure *)enclosure;
+- (void)addAuthor:(RSParsedAuthor *)author;
 
 @end
 
+NS_ASSUME_NONNULL_END

--- a/Sources/ObjC/RSParsedAuthor.h
+++ b/Sources/ObjC/RSParsedAuthor.h
@@ -8,12 +8,16 @@
 
 @import Foundation;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface RSParsedAuthor : NSObject
 
 @property (nonatomic, nullable) NSString *name;
 @property (nonatomic, nullable) NSString *emailAddress;
 @property (nonatomic, nullable) NSString *url;
 
-+ (instancetype _Nonnull )authorWithSingleString:(NSString *_Nonnull)s; // Don’t know which property it is. Guess based on contents of the string. Common with RSS.
++ (instancetype)authorWithSingleString:(NSString *)s; // Don’t know which property it is. Guess based on contents of the string. Common with RSS.
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/ObjC/RSParsedEnclosure.h
+++ b/Sources/ObjC/RSParsedEnclosure.h
@@ -17,6 +17,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable) NSString *mimeType;
 @property (nonatomic, nullable) NSString *title;
 
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithURLString:(NSString *)urlString NS_DESIGNATED_INITIALIZER;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/ObjC/RSParsedEnclosure.m
+++ b/Sources/ObjC/RSParsedEnclosure.m
@@ -10,4 +10,16 @@
 
 @implementation RSParsedEnclosure
 
+- (instancetype)initWithURLString:(NSString *)urlString {
+
+	self = [super init];
+	if (!self) {
+		return nil;
+	}
+
+	_url = urlString;
+
+	return self;
+}
+
 @end

--- a/Sources/ObjC/RSParsedFeed.h
+++ b/Sources/ObjC/RSParsedFeed.h
@@ -10,14 +10,18 @@
 
 @class RSParsedArticle;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface RSParsedFeed : NSObject
 
-- (nonnull instancetype)initWithURLString:(NSString * _Nonnull)urlString title:(NSString * _Nullable)title link:(NSString * _Nullable)link language:(NSString * _Nullable)language articles:(NSArray <RSParsedArticle *>* _Nonnull)articles;
+- (instancetype)initWithURLString:(NSString *)urlString title:(NSString * _Nullable)title link:(NSString * _Nullable)link language:(NSString * _Nullable)language articles:(NSArray <RSParsedArticle *>*)articles;
 
-@property (nonatomic, readonly, nonnull) NSString *urlString;
+@property (nonatomic, readonly) NSString *urlString;
 @property (nonatomic, readonly, nullable) NSString *title;
 @property (nonatomic, readonly, nullable) NSString *link;
 @property (nonatomic, readonly, nullable) NSString *language;
-@property (nonatomic, readonly, nonnull) NSSet <RSParsedArticle *>*articles;
+@property (nonatomic, readonly) NSSet <RSParsedArticle *>*articles;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/ObjC/RSParsedFeed.h
+++ b/Sources/ObjC/RSParsedFeed.h
@@ -14,7 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RSParsedFeed : NSObject
 
-- (instancetype)initWithURLString:(NSString *)urlString title:(NSString * _Nullable)title link:(NSString * _Nullable)link language:(NSString * _Nullable)language articles:(NSArray <RSParsedArticle *>*)articles;
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithURLString:(NSString *)urlString title:(NSString * _Nullable)title link:(NSString * _Nullable)link language:(NSString * _Nullable)language articles:(NSArray <RSParsedArticle *>*)articles NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, readonly) NSString *urlString;
 @property (nonatomic, readonly, nullable) NSString *title;

--- a/Sources/ObjC/RSRSSParser.h
+++ b/Sources/ObjC/RSRSSParser.h
@@ -11,9 +11,13 @@
 @class ParserData;
 @class RSParsedFeed;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface RSRSSParser : NSObject
 
 + (RSParsedFeed *)parseFeedWithData:(ParserData *)parserData;
 
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/ObjC/RSRSSParser.m
+++ b/Sources/ObjC/RSRSSParser.m
@@ -266,8 +266,7 @@ static const NSInteger kLanguageLength = 9;
 		return;
 	}
 
-	RSParsedEnclosure *enclosure = [[RSParsedEnclosure alloc] init];
-	enclosure.url = url;
+	RSParsedEnclosure *enclosure = [[RSParsedEnclosure alloc] initWithURLString:url];
 	enclosure.length = [attributes[kLengthKey] integerValue];
 	enclosure.mimeType = attributes[kTypeKey];
 

--- a/Sources/ObjC/RSSAXHTMLParser.h
+++ b/Sources/ObjC/RSSAXHTMLParser.h
@@ -16,12 +16,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @optional
 
-- (void)saxParser:(RSSAXHTMLParser *)SAXParser XMLStartElement:(const unsigned char *)localName attributes:(const unsigned char *_Nullable*_Nullable)attributes;
+- (void)saxParser:(RSSAXHTMLParser *)SAXParser XMLStartElement:(const unsigned char * _Nullable)localName attributes:(const unsigned char * _Nullable * _Nullable)attributes;
 
-- (void)saxParser:(RSSAXHTMLParser *)SAXParser XMLEndElement:(nullable const unsigned char *)localName;
+- (void)saxParser:(RSSAXHTMLParser *)SAXParser XMLEndElement:(const unsigned char * _Nullable)localName;
 
 // Length is guaranteed to be greater than 0.
-- (void)saxParser:(RSSAXHTMLParser *)SAXParser XMLCharactersFound:(nullable const unsigned char *)characters length:(NSUInteger)length;
+- (void)saxParser:(RSSAXHTMLParser *)SAXParser XMLCharactersFound:(const unsigned char * _Nullable)characters length:(NSUInteger)length;
 
 - (void)saxParserDidReachEndOfDocument:(RSSAXHTMLParser *)SAXParser; // If canceled, may not get called (but might).
 
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 // Delegate can call from within XMLStartElement.
 
-- (nullable NSDictionary *)attributesDictionary:(const unsigned char *_Nullable*_Nullable)attributes;
+- (nullable NSDictionary *)attributesDictionary:(const unsigned char * _Nullable * _Nullable)attributes;
 
 
 @end

--- a/Sources/ObjC/RSSAXParser.h
+++ b/Sources/ObjC/RSSAXParser.h
@@ -8,6 +8,8 @@
 
 @import Foundation;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*Thread-safe, not re-entrant.
 
  Calls to the delegate will happen on the same thread where the parser runs.
@@ -24,18 +26,18 @@
 
 @optional
 
-- (void)saxParser:(RSSAXParser *)SAXParser XMLStartElement:(const unsigned char *)localName prefix:(const unsigned char *)prefix uri:(const unsigned char *)uri numberOfNamespaces:(NSInteger)numberOfNamespaces namespaces:(const unsigned char **)namespaces numberOfAttributes:(NSInteger)numberOfAttributes numberDefaulted:(int)numberDefaulted attributes:(const unsigned char **)attributes;
+- (void)saxParser:(RSSAXParser *)SAXParser XMLStartElement:(const unsigned char * _Nullable)localName prefix:(const unsigned char * _Nullable)prefix uri:(const unsigned char * _Nullable)uri numberOfNamespaces:(NSInteger)numberOfNamespaces namespaces:(const unsigned char * _Nullable * _Nullable)namespaces numberOfAttributes:(NSInteger)numberOfAttributes numberDefaulted:(int)numberDefaulted attributes:(const unsigned char * _Nullable * _Nullable)attributes;
 
-- (void)saxParser:(RSSAXParser *)SAXParser XMLEndElement:(const unsigned char *)localName prefix:(const unsigned char *)prefix uri:(const unsigned char *)uri;
+- (void)saxParser:(RSSAXParser *)SAXParser XMLEndElement:(const unsigned char * _Nullable)localName prefix:(const unsigned char * _Nullable)prefix uri:(const unsigned char * _Nullable)uri;
 
 // Length is guaranteed to be greater than 0.
-- (void)saxParser:(RSSAXParser *)SAXParser XMLCharactersFound:(const unsigned char *)characters length:(NSUInteger)length;
+- (void)saxParser:(RSSAXParser *)SAXParser XMLCharactersFound:(const unsigned char * _Nullable)characters length:(NSUInteger)length;
 
 - (void)saxParserDidReachEndOfDocument:(RSSAXParser *)SAXParser; /*If canceled, may not get called (but might).*/
 
-- (NSString *)saxParser:(RSSAXParser *)SAXParser internedStringForName:(const unsigned char *)name prefix:(const unsigned char *)prefix; /*Okay to return nil. Prefix may be nil.*/
+- (nullable NSString *)saxParser:(RSSAXParser *)SAXParser internedStringForName:(const unsigned char * _Nullable)name prefix:(const unsigned char * _Nullable)prefix; /*Okay to return nil. Prefix may be nil.*/
 
-- (NSString *)saxParser:(RSSAXParser *)SAXParser internedStringForValue:(const void *)bytes length:(NSUInteger)length;
+- (nullable NSString *)saxParser:(RSSAXParser *)SAXParser internedStringForValue:(const void * _Nullable)bytes length:(NSUInteger)length;
 
 @end
 
@@ -56,14 +58,16 @@ BOOL RSSAXEqualTags(const unsigned char *localName, const char *tag, NSInteger t
 - (void)finishParsing;
 - (void)cancel;
 
-@property (nonatomic, strong, readonly) NSData *currentCharacters; /*nil if not storing characters. UTF-8 encoded.*/
-@property (nonatomic, strong, readonly) NSString *currentString; /*Convenience to get string version of currentCharacters.*/
-@property (nonatomic, strong, readonly) NSString *currentStringWithTrimmedWhitespace;
+@property (nonatomic, strong, nullable, readonly) NSData *currentCharacters; /*nil if not storing characters. UTF-8 encoded.*/
+@property (nonatomic, strong, nullable, readonly) NSString *currentString; /*Convenience to get string version of currentCharacters.*/
+@property (nonatomic, strong, nullable, readonly) NSString *currentStringWithTrimmedWhitespace;
 
 - (void)beginStoringCharacters; /*Delegate can call from XMLStartElement. Characters will be available in XMLEndElement as currentCharacters property. Storing characters is stopped after each XMLEndElement.*/
 
 /*Delegate can call from within XMLStartElement. Returns nil if numberOfAttributes < 1.*/
 
-- (NSDictionary *)attributesDictionary:(const unsigned char **)attributes numberOfAttributes:(NSInteger)numberOfAttributes;
+- (NSDictionary *)attributesDictionary:(const unsigned char * _Nullable * _Nullable)attributes numberOfAttributes:(NSInteger)numberOfAttributes;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Swift/Feeds/XML/AtomParser.swift
+++ b/Sources/Swift/Feeds/XML/AtomParser.swift
@@ -24,9 +24,7 @@ public struct AtomParser {
 
 	public static func parse(_ parserData: ParserData) -> ParsedFeed? {
 
-		if let rsParsedFeed = RSAtomParser.parseFeed(with: parserData) {
-			return RSParsedFeedTransformer.parsedFeed(rsParsedFeed)
-		}
-		return nil
+		let rsParsedFeed = RSAtomParser.parseFeed(with: parserData)
+		return RSParsedFeedTransformer.parsedFeed(rsParsedFeed)
 	}
 }

--- a/Sources/Swift/Feeds/XML/RSSParser.swift
+++ b/Sources/Swift/Feeds/XML/RSSParser.swift
@@ -21,9 +21,7 @@ public struct RSSParser {
 
 	public static func parse(_ parserData: ParserData) -> ParsedFeed? {
 
-		if let rsParsedFeed = RSRSSParser.parseFeed(with: parserData) {
-			return RSParsedFeedTransformer.parsedFeed(rsParsedFeed)
-		}
-		return nil
+		let rsParsedFeed = RSRSSParser.parseFeed(with: parserData)
+		return RSParsedFeedTransformer.parsedFeed(rsParsedFeed)
 	}
 }


### PR DESCRIPTION
This PR adds proper nullability specifiers for all public ObjC headers.

The main purpose of this PR is to prevent implicitly unwrapped optionals on generated Swift interfaces. It also adds `NS_ASSUME_NONNULL_BEGIN` and `NS_ASSUME_NONNULL_END` for all public header files, `nonnull` or `_Nonnull` are removed.

According to [the official guide](https://developer.apple.com/swift/blog/?id=25), `nullable` is preferred for object and block types in ObjC method declarations compared to `_Nullalbe`, this PR conforms to this convension.