### PR TITLE
Make ParsedAttachment Codable

### DIFF
--- a/Sources/Swift/Feeds/ParsedAttachment.swift
+++ b/Sources/Swift/Feeds/ParsedAttachment.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct ParsedAttachment: Hashable {
+public struct ParsedAttachment: Hashable, Codable {
 
 	public let url: String
 	public let mimeType: String?


### PR DESCRIPTION
This allows storing ParsedAttachment type in the same way as ParsedAuthor.