### PR TITLE
fix parsing dates with more than 3 digits for second fraction, resolves #67

### DIFF
--- a/Sources/ObjC/RSDateParser.m
+++ b/Sources/ObjC/RSDateParser.m
@@ -389,6 +389,9 @@ static NSDate *RSParseW3CWithBytes(const char *bytes, NSUInteger numberOfBytes) 
 	if (hasMilliseconds) {
 		milliseconds = nextNumericValue(bytes, numberOfBytes, currentIndex, 3, &finalIndex);
 		currentIndex = finalIndex + 1;
+
+		// Igore more than 3 digits for fraction of a second
+		while (currentIndex < numberOfBytes && isdigit(bytes[currentIndex])) currentIndex++;
 	}
 
 	timeZoneOffset = parsedTimeZoneOffset(bytes, numberOfBytes, currentIndex);

--- a/Tests/RSParserTests/RSDateParserTests.swift
+++ b/Tests/RSParserTests/RSDateParserTests.swift
@@ -11,7 +11,7 @@ import RSParser
 
 class RSDateParserTests: XCTestCase {
 	
-	static func dateWithValues(_ year: Int, _ month: Int, _ day: Int, _ hour: Int, _ minute: Int, _ second: Int) -> Date {
+	static func dateWithValues(_ year: Int, _ month: Int, _ day: Int, _ hour: Int, _ minute: Int, _ second: Int, _ milliseconds: Int = 0) -> Date {
 		var dateComponents = DateComponents()
 		dateComponents.calendar = Calendar.current
 		dateComponents.timeZone = TimeZone(secondsFromGMT: 0)
@@ -22,6 +22,7 @@ class RSDateParserTests: XCTestCase {
 		dateComponents.hour = hour
 		dateComponents.minute = minute
 		dateComponents.second = second
+		dateComponents.nanosecond = milliseconds * 1000000
 		
 		return dateComponents.date!
 	}
@@ -100,9 +101,9 @@ class RSDateParserTests: XCTestCase {
 		XCTAssertEqual(d, expectedDateResult)
 	}
 
-//	func testHighMillisecondDate() {
-//		let expectedDateResult = Self.dateWithValues(2021, 03, 29, 10, 46, 56)
-//		let d = RSDateWithString("2021-03-29T10:46:56.516941+00:00")
-//		XCTAssertEqual(d, expectedDateResult)
-//	}
+	func testHighMillisecondDate() {
+		let expectedDateResult = Self.dateWithValues(2021, 03, 29, 10, 46, 56, 516)
+		let d = RSDateWithString("2021-03-29T10:46:56.516941+00:00")
+		XCTAssertEqual(d!.timeIntervalSince1970, expectedDateResult.timeIntervalSince1970, accuracy: 0.000001)
+	}
 }


### PR DESCRIPTION
I finally got my hands on investigating why NetNewsWire has problems with dates produced by ruby rss library. Problem is that dates will be produced with 6 digits for second fraction and this will currently be parsed as timezone, so date will be thrown ahead by multiple hours and if date changes it will randomly change.

The simplest solution was to make the parser just ignore extra digits.